### PR TITLE
Related to #81: Better logging and added missing image folder

### DIFF
--- a/validator_node/src/constants.rs
+++ b/validator_node/src/constants.rs
@@ -8,4 +8,4 @@ pub const TEMP_FOLDER: &str = "./temp";
 #[allow(dead_code)]
 pub const IPFS_API_BASE_URL: &str = "https://ipfs.original.works";
 #[allow(dead_code)]
-pub const IPFS_API_CAT_FILE: &str = "/api/v0/cat";
+pub const IPFS_API_CAT_FILE: &str = "/ipfs/";

--- a/validator_node/src/ipfs.rs
+++ b/validator_node/src/ipfs.rs
@@ -3,7 +3,7 @@ use crate::contracts::QueueHeadData;
 use anyhow::{anyhow, Context};
 use blob_codec::BlobCodec;
 use cid::Cid;
-use ddex_parser::{DdexParser, NewReleaseMessage};
+use ddex_parser::DdexParser; // only import what you need
 use log_macros::{format_error, log_warn, log_error, log_info};
 use multihash_codetable::{Code, MultihashDigest};
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,7 @@ use std::{
     path::Path,
     process::Command,
 };
-
+use reqwest::blocking::Client; // synchronous
 
 #[derive(Serialize, Deserialize)]
 struct BlobMetadata {
@@ -27,19 +27,17 @@ struct BlobMetadata {
     blob_ipfs_cid: String,
 }
 
+/// Fully synchronous check for each CID (via POST to /api/v0/cat).
 #[allow(dead_code)]
-pub async fn check_file_accessibility(cids: Vec<String>) -> anyhow::Result<()> {
-    println!("{cids:?}");
-    let client = reqwest::Client::new();
+pub fn check_file_accessibility(cids: Vec<String>) -> anyhow::Result<()> {
+    println!("Checking these CIDs for accessibility: {:?}", cids);
+    let client = Client::new(); // blocking client
 
     for cid in cids {
         let response = client
-            .post(format!(
-                "{}{}?arg={}",
-                IPFS_API_BASE_URL, IPFS_API_CAT_FILE, cid
-            ))
+            .post(format!("{}{}{}", IPFS_API_BASE_URL, IPFS_API_CAT_FILE, cid))
             .send()
-            .await?;
+            .with_context(|| format!("Failed to POST cat request for CID={}", cid))?;
 
         if response.status() != 200 {
             return Err(format_error!("Image file not found in IPFS: {}", cid));
@@ -49,12 +47,15 @@ pub async fn check_file_accessibility(cids: Vec<String>) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn prepare_blob_folder(
+/// Decodes the blob, writes JSON out, downloads any images to `images/`,
+/// stores the raw blob in `blob/`, and writes `metadata.json` (all synchronously).
+pub fn prepare_blob_folder(
     blob: [u8; 131072],
     queue_head_data: &QueueHeadData,
 ) -> anyhow::Result<()> {
     let blob_folder_path = Path::new(constants::TEMP_FOLDER);
 
+    // Clear out any old data
     if blob_folder_path.is_dir() {
         fs::remove_dir_all(blob_folder_path)?;
     }
@@ -62,46 +63,95 @@ pub async fn prepare_blob_folder(
     fs::create_dir_all(blob_folder_path.join("blob"))?;
     fs::create_dir_all(blob_folder_path.join("images"))?;
 
+    // Decode the blob
     let blob_codec = BlobCodec::from_vec(blob.into())?;
     let message_vecs = blob_codec.decode()?;
 
-    let mut reader: Cursor<&Vec<u8>>;
-    let mut parsed_messages: Vec<NewReleaseMessage> = vec![];
+    let client = Client::new(); // We'll reuse this blocking client
 
-    for (i, message_vec) in message_vecs.iter().enumerate() {
-        reader = Cursor::new(&message_vec);
-        let parsed = match DdexParser::from_json_reader(reader) {
-            std::result::Result::Ok(p) => p,
+    // We'll store images with sequential filenames: 0.avif, 1.avif, etc.
+    let mut image_counter = 0usize;
+
+    for (msg_idx, message_bytes) in message_vecs.iter().enumerate() {
+        // parse the JSON
+        let parsed = match DdexParser::from_json_reader(Cursor::new(&message_bytes)) {
+            Ok(p) => p,
             Err(e) => {
-                log_warn!(
-                    "Skipping message upload {} due to parsing error: {:?}",
-                    i,
-                    e
-                );
+                log_warn!("Skipping message upload {} due to parsing error: {:?}", msg_idx, e);
                 continue;
             }
         };
-        let json_output = match parsed.to_json_string_pretty() {
-            std::result::Result::Ok(json) => json,
+
+        // Write out the pretty JSON
+        match parsed.to_json_string_pretty() {
+            Ok(json_output) => {
+                fs::write(blob_folder_path.join(format!("json/{msg_idx}.json")), json_output)?;
+            }
             Err(e) => {
                 log_warn!(
                     "Skipping message upload {} due to JSON serialization error: {:?}",
-                    i,
+                    msg_idx,
                     e
                 );
                 continue;
             }
         };
 
-        fs::write(
-            &blob_folder_path.join(format!("json/{}.json", i)),
-            json_output,
-        )?;
-        parsed_messages.push(parsed);
+        // -------------------------------------------------
+        //   Download images from resource_list.images
+        // -------------------------------------------------
+        let resource_list = &parsed.resource_list;
+
+        // If `resource_list.images` is a Vec, loop directly:
+        for image in &resource_list.images {
+            for tech_detail in &image.technical_details {
+                // tech_detail.file is an Option<File>, so do:
+                if let Some(file) = &tech_detail.file {
+                    let cid = &file.uri;
+                    log_info!("Found image CID: {}", cid);
+
+                    let url = format!("{}{}{}", IPFS_API_BASE_URL, IPFS_API_CAT_FILE, cid);
+                    log_info!("Downloading image CID: {} from {}", cid, url);
+
+                    let response = client
+                        .get(&url)
+                        .send()
+                        .with_context(|| format!("Failed to download CID={}", cid))?;
+
+                    if response.status() != 200 {
+                        log_warn!(
+                            "Could not download image CID={} => status={}",
+                            cid,
+                            response.status()
+                        );
+                        continue;
+                    }
+
+                    let bytes = response.bytes().with_context(|| {
+                        format!("Failed to read bytes from IPFS for CID={}", cid)
+                    })?;
+
+                    let out_path = blob_folder_path
+                        .join("images")
+                        .join(format!("{image_counter}.avif"));
+
+                    fs::write(&out_path, &bytes).with_context(|| {
+                        format!("Could not write downloaded image to {:?}", &out_path)
+                    })?;
+
+                    image_counter += 1;
+                } else {
+                    log_warn!("Skipping an image with no file entry in tech_detail");
+                }
+            }
+        }
     }
-    let mut blob_file = File::create(blob_folder_path.join(format!("blob/blob_data.bin")))?;
+
+    // Write the raw blob to disk
+    let mut blob_file = File::create(blob_folder_path.join("blob/blob_data.bin"))?;
     blob_file.write_all(&blob)?;
 
+    // Write metadata
     let blob_metadata = BlobMetadata {
         versioned_hash: queue_head_data.versioned_blobhash.to_string(),
         transaction_hash: queue_head_data.transaction_hash.to_string(),
@@ -113,40 +163,33 @@ pub async fn prepare_blob_folder(
     };
 
     let blob_metadata_json_string = serde_json::to_string_pretty(&blob_metadata)?;
-    let blob_metadata_json_path = blob_folder_path.join(format!("blob/metadata.json"));
+    let blob_metadata_json_path = blob_folder_path.join("blob/metadata.json");
     let mut file = File::create(blob_metadata_json_path)?;
     file.write_all(blob_metadata_json_string.as_bytes())?;
 
     Ok(())
 }
 
+/// Compute a CID for the file at `TEMP_FOLDER/blob/blob_data.bin`
 fn calculate_blob_data_cid() -> anyhow::Result<String> {
     const RAW: u64 = 0x55;
-    let blob_folder_path = Path::new(constants::TEMP_FOLDER).join("blob/blob_data.bin");
-    let data = fs::read(blob_folder_path).expect("Failed to read file");
+    let blob_path = Path::new(constants::TEMP_FOLDER).join("blob/blob_data.bin");
+    let data = fs::read(&blob_path).expect("Failed to read file");
     let h = Code::Sha2_256.digest(&data);
     let cid = Cid::new_v1(RAW, h);
     Ok(cid.to_string())
 }
 
-///
-/// Uploads the contents of the `TEMP_FOLDER` directory to IPFS via `w3 up <folder>`,
-/// extracts and returns the CID, logs it, and then removes everything **inside** `TEMP_FOLDER`
-/// (but not the folder itself).
-///
-/// If anything fails (command error, parse error, etc.), logs an error and returns `Err(...)`.
-///
+/// Upload the contents of `TEMP_FOLDER` to IPFS via `w3 up <folder>`, parse the CID,
+/// log it, then remove all files in `TEMP_FOLDER`.
 pub fn upload_blob_folder_and_cleanup() -> anyhow::Result<String> {
-    // This is your top-level folder (e.g. "tmp" or "temp" or similar).
-    let folder_path = Path::new(crate::constants::TEMP_FOLDER);
+    let folder_path = Path::new(constants::TEMP_FOLDER);
 
-    // --- 1) Invoke `w3 up <folder>` synchronously ---
     let output = Command::new("w3")
         .args(["up", folder_path.to_str().unwrap()])
         .output()
         .with_context(|| format!("Failed to run `w3 up {}`", folder_path.display()))?;
 
-    // If `w3` returned a non-zero exit code, treat that as failure
     if !output.status.success() {
         let msg = format!(
             "`w3 up` command failed with status: {:?}\nStdout: {}\nStderr: {}",
@@ -160,22 +203,12 @@ pub fn upload_blob_folder_and_cleanup() -> anyhow::Result<String> {
 
     let stdout_str = String::from_utf8_lossy(&output.stdout);
 
-    // --- 2) Parse the CID from the lines like:
-    //     "⁂ https://w3s.link/ipfs/bafy...something..."
-    //
-    //     We want to extract only the part after the last '/'
-    //     e.g. "bafybeibtetuqfs3xwr7makqdh6yebiuwkuxrerkjx5f6swmauzv6ivpevi"
-    //
     let mut cid: Option<String> = None;
     for line in stdout_str.lines() {
         if line.starts_with("⁂ https://") {
-            // "⁂ https://w3s.link/ipfs/bafybeibtetuqfs3x..."
             let tokens: Vec<_> = line.split_whitespace().collect();
             if tokens.len() >= 2 {
-                // tokens[0] = "⁂"
-                // tokens[1] = "https://w3s.link/ipfs/bafy..."
                 if let Some(url) = tokens.get(1) {
-                    // isolate the string after the final slash
                     if let Some(pos) = url.rfind('/') {
                         cid = Some(url[(pos + 1)..].to_string());
                         break;
@@ -198,13 +231,8 @@ pub fn upload_blob_folder_and_cleanup() -> anyhow::Result<String> {
     };
 
     log_info!("Successfully uploaded folder to IPFS. CID: {}", cid);
-    log_info!(
-        "URL: https://{}.ipfs.w3s.link/",
-        cid
-    );
-    
+    log_info!("URL: https://{}.ipfs.w3s.link/", cid);
 
-    // --- 3) Remove the *contents* of `TEMP_FOLDER`, but leave the folder itself ---
     for entry in fs::read_dir(folder_path)? {
         let path = entry?.path();
         if path.is_dir() {
@@ -214,7 +242,5 @@ pub fn upload_blob_folder_and_cleanup() -> anyhow::Result<String> {
         }
     }
 
-    // Return the parsed CID
     Ok(cid)
 }
-

--- a/validator_node/src/lib.rs
+++ b/validator_node/src/lib.rs
@@ -130,7 +130,7 @@ async fn validate_blobs(
         "Pinning message JSON files to IPFS",
     );
 
-    ipfs::prepare_blob_folder(blob, &queue_head_data).await?;
+    ipfs::prepare_blob_folder(blob, &queue_head_data)?;
 
     let cid = ipfs::upload_blob_folder_and_cleanup()?;
     //log_info!("Folder successfully uploaded to IPFS with CID: {}", cid);


### PR DESCRIPTION
Added image support

```
 2025-03-12T22:45:37.377Z INFO  validator_node > Found NVIDIA GPU: Model="NVIDIA GeForce RTX 3070 Ti Laptop GPU", Memory=8192 MiB
 2025-03-12T22:45:37.377Z INFO  validator_node > Detected NVIDIA GPU(s). Maximum memory: 8192 MiB
 2025-03-12T22:45:37.377Z INFO  validator_node > Public key used: 0x3928634428d9c06ae4d0b36897c9861720c3aea2
 2025-03-12T22:45:37.377Z INFO  validator_node > START_BLOCK=3477300
 2025-03-12T22:45:37.377Z INFO  validator_node > SEGMENT_LIMIT_PO2=18
 2025-03-12T22:45:37.377Z INFO  validator_node > ENVIRONMENT=development
 2025-03-12T22:45:37.872Z INFO  validator_node > Queue head points to 0x0199bfe0f0b6f521951675e284d9e384e46cb9ebcef53a1411c5ead78271732a [src/lib.rs:103]
 2025-03-12T22:45:38.556Z INFO  validator_node::beacon_chain > Finding a blob... [src/beacon_chain.rs:112]
BeaconBlock { data: BeaconBlockData { message: BeaconBlockDataMessage { slot: "3823767" } } }
 2025-03-12T22:45:39.746Z INFO  validator_node::ipfs         > Found image CID: bafkreierg4sbc4oom5xx5tudzdtvo5ybz5v57lbnn73f5fr5oodptua4hq [src/ipfs.rs:111]
 2025-03-12T22:45:39.746Z INFO  validator_node::ipfs         > Downloading image CID: bafkreierg4sbc4oom5xx5tudzdtvo5ybz5v57lbnn73f5fr5oodptua4hq from https://ipfs.original.works/ipfs/bafkreierg4sbc4oom5xx5tudzdtvo5ybz5v57lbnn73f5fr5oodptua4hq [src/ipfs.rs:114]
 2025-03-12T22:45:41.650Z INFO  validator_node::ipfs         > Found image CID: bafkreib6hmw5mwi74qum3s7jch6kjz66gd7yffa5nmnc4yty6vr55f55ei [src/ipfs.rs:111]
 2025-03-12T22:45:41.650Z INFO  validator_node::ipfs         > Downloading image CID: bafkreib6hmw5mwi74qum3s7jch6kjz66gd7yffa5nmnc4yty6vr55f55ei from https://ipfs.original.works/ipfs/bafkreib6hmw5mwi74qum3s7jch6kjz66gd7yffa5nmnc4yty6vr55f55ei [src/ipfs.rs:114]
 2025-03-12T22:45:42.359Z INFO  validator_node::ipfs         > Found image CID: bafkreibpysdqenu3j4hekj4555fmh5n5xy7rjamowqymcyvzcuz54i5p2q [src/ipfs.rs:111]
 2025-03-12T22:45:42.359Z INFO  validator_node::ipfs         > Downloading image CID: bafkreibpysdqenu3j4hekj4555fmh5n5xy7rjamowqymcyvzcuz54i5p2q from https://ipfs.original.works/ipfs/bafkreibpysdqenu3j4hekj4555fmh5n5xy7rjamowqymcyvzcuz54i5p2q [src/ipfs.rs:114]
 2025-03-12T22:45:43.385Z INFO  validator_node::ipfs         > Found image CID: bafkreibgj5bewum7rgnlfrhcto4w33xrzsykqo5wifscecp5etfer4g2qa [src/ipfs.rs:111]
 2025-03-12T22:45:43.385Z INFO  validator_node::ipfs         > Downloading image CID: bafkreibgj5bewum7rgnlfrhcto4w33xrzsykqo5wifscecp5etfer4g2qa from https://ipfs.original.works/ipfs/bafkreibgj5bewum7rgnlfrhcto4w33xrzsykqo5wifscecp5etfer4g2qa [src/ipfs.rs:114]
 2025-03-12T22:45:44.206Z INFO  validator_node::ipfs         > Found image CID: bafkreibgj5bewum7rgnlfrhcto4w33xrzsykqo5wifscecp5etfer4g2qa [src/ipfs.rs:111]
 2025-03-12T22:45:44.206Z INFO  validator_node::ipfs         > Downloading image CID: bafkreibgj5bewum7rgnlfrhcto4w33xrzsykqo5wifscecp5etfer4g2qa from https://ipfs.original.works/ipfs/bafkreibgj5bewum7rgnlfrhcto4w33xrzsykqo5wifscecp5etfer4g2qa [src/ipfs.rs:114]
 2025-03-12T22:45:55.582Z INFO  validator_node::ipfs         > Successfully uploaded folder to IPFS. CID: bafybeicc3kvcgna6nwfyngrlslkckzj6urpz2bh3x4nnyclb6r4mi2qwda [src/ipfs.rs:233]
 2025-03-12T22:45:55.582Z INFO  validator_node::ipfs         > URL: https://bafybeicc3kvcgna6nwfyngrlslkckzj6urpz2bh3x4nnyclb6r4mi2qwda.ipfs.w3s.link/ [src/ipfs.rs:234]
 2025-03-12T22:45:55.583Z INFO  validator_node::prover_wrapper > Proving... [src/prover_wrapper.rs:44]
Parsing blob took roughly 1283177 cycles
Calculating digest took roughly 402819 cycles
Decoding blob took roughly 1620231 cycles
Parsing messages took roughly 3669244 cycles
TOTAL 7077533 cycles
 2025-03-12T22:45:56.073Z INFO  risc0_zkvm::host::server::exec::executor > execution time: 194.418073ms
 2025-03-12T22:45:56.073Z INFO  risc0_zkvm::host::server::session        > number of segments: 89
 2025-03-12T22:45:56.073Z INFO  risc0_zkvm::host::server::session        > total cycles: 23134208
 2025-03-12T22:45:56.073Z INFO  risc0_zkvm::host::server::session        > user cycles: 7083154 (30.62%)
 2025-03-12T22:45:56.073Z INFO  risc0_zkvm::host::server::session        > paging cycles: 15553048 (67.23%)
```